### PR TITLE
Add agent_servers and adjust buffer font size in Zed settings

### DIFF
--- a/config/zed_settings.jsonc
+++ b/config/zed_settings.jsonc
@@ -7,12 +7,20 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
+  "agent_servers": {
+    "claude-acp": {
+      "type": "registry",
+    },
+    "gemini": {
+      "type": "registry",
+    },
+  },
   "base_keymap": "JetBrains",
   "edit_predictions": {
     "provider": "none",
   },
   "ui_font_size": 16,
-  "buffer_font_size": 16,
+  "buffer_font_size": 15,
   // Alternatively: "split"
   "diff_view_style": "unified",
   "preferred_line_length": 100,


### PR DESCRIPTION
Zed 0.227.1 has moved internal agent servers to be installed through the registry which requires adding the agent_servers configuration (See: https://zed.dev/releases/stable/0.227.1).

Also reduce buffer font size from 16 to 15.
from 16 to 15.