### PR TITLE
Add tailscale CLI and launchd-managed tailscaled daemon

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -58,11 +74,67 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "tailscale": "tailscale"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tailscale": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1773326561,
+        "narHash": "sha256-BHm3Iq3eREE7fxosS4TLglymH1b3r9JNEVGfjQCzmTY=",
+        "owner": "tailscale",
+        "repo": "tailscale",
+        "rev": "7412fc00acbd3434c57f20f685a3273e8fe75e57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tailscale",
+        "repo": "tailscale",
+        "rev": "7412fc00acbd3434c57f20f685a3273e8fe75e57",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     home-manager = {
       url = "github:nix-community/home-manager/release-25.11";
@@ -13,19 +14,47 @@
       url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Pinned past v1.96.4: that tag's flake uses buildGo125Module but its
+    # go.mod needs Go 1.26.1+. Switch to a tag ref once v1.97.0+ is released.
+    tailscale = {
+      url = "github:tailscale/tailscale/7412fc00acbd3434c57f20f685a3273e8fe75e57";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
   };
 
-  outputs = inputs@{ self, nixpkgs, home-manager, nix-darwin }:
+  outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, home-manager, nix-darwin, tailscale }:
   let
     username = "kevintham";
     homeDirectory = "/Users/${username}";
+    system = "aarch64-darwin";
+
+    tailscalePkg = tailscale.packages.${system}.tailscale;
 
     darwinConfiguration = { pkgs, ... }: {
       # List packages installed in system profile. To search by name, run:
       # $ nix-env -qaP | grep wget
       environment.systemPackages = [
         pkgs.vim
+        tailscalePkg
       ];
+
+      # tailscaled is started by launchd at boot. First-time setup on a
+      # fresh machine requires a one-time `sudo tailscale up` to authenticate;
+      # node state persists in /Library/Tailscale/ and re-auths on reboot.
+      #
+      # Logs:    /var/log/tailscaled.log
+      # Restart: sudo launchctl kickstart -k system/com.tailscale.tailscaled
+      launchd.daemons.tailscaled = {
+        command = "${tailscalePkg}/bin/tailscaled";
+        serviceConfig = {
+          Label = "com.tailscale.tailscaled";
+          RunAtLoad = true;
+          KeepAlive = true;
+          StandardOutPath = "/var/log/tailscaled.log";
+          StandardErrorPath = "/var/log/tailscaled.log";
+        };
+      };
 
       nix.enable = false;
 


### PR DESCRIPTION
Tracks upstream main via a flake input (following nixpkgs-unstable since upstream follows the same); nix-darwin writes the launchd plist so the daemon starts at boot and restarts on crash without running `tailscaled install-system-daemon`.