### PR TITLE
Add zed configs

### DIFF
--- a/config/zed_settings.jsonc
+++ b/config/zed_settings.jsonc
@@ -7,6 +7,18 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
+  "git_panel": {
+    "dock": "left",
+  },
+  "agent": {
+    "dock": "right",
+    "sidebar_side": "right",
+    "favorite_models": [],
+    "model_parameters": [],
+  },
+  "project_panel": {
+    "dock": "left",
+  },
   "agent_servers": {
     "claude-acp": {
       "type": "registry",


### PR DESCRIPTION
Revert new default agentic layout in https://zed.dev/blog/parallel-agents. Move threads panel and agent panel to the right side, and the project and git panel back to the left