### PR TITLE
Update zed soft_wrap setting to "bounded"

### DIFF
--- a/config/zed_settings.jsonc
+++ b/config/zed_settings.jsonc
@@ -36,7 +36,7 @@
   // Alternatively: "split"
   "diff_view_style": "unified",
   "preferred_line_length": 100,
-  "soft_wrap": "preferred_line_length",
+  "soft_wrap": "bounded",
   "theme": {
     "mode": "system",
     "light": "One Light",


### PR DESCRIPTION
## Context

The `"preferred_line_length"` value was replaced with `"bounded"` in zed-industries/zed#54051.

## Changes
- Update zed's `soft_wrap` setting to `"bounded"`